### PR TITLE
[BUG] Language changes when dark/light mode toggled #19

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -6,21 +6,22 @@
 
     <application
         android:allowBackup="false"
+        android:configChanges="uiMode"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"
+        android:hardwareAccelerated="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
+        android:localeConfig="@xml/locales_config"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.AppCompat.Light.NoActionBar"
-        tools:targetApi="tiramisu"
-        android:hardwareAccelerated="true"
-        android:localeConfig="@xml/locales_config">
+        tools:targetApi="tiramisu">
         <activity
             android:name=".view.activities.MainViewActivity"
-            android:windowSoftInputMode="adjustPan"
+            android:exported="false"
             android:launchMode="singleTop"
-            android:exported="false" />
+            android:windowSoftInputMode="adjustPan" />
         <activity
             android:name=".view.activities.LoginActivity"
             android:exported="true">

--- a/app/src/main/java/com/gero/newpass/ContextWrapper/NewPassContextWrapper.java
+++ b/app/src/main/java/com/gero/newpass/ContextWrapper/NewPassContextWrapper.java
@@ -1,0 +1,57 @@
+package com.gero.newpass.ContextWrapper;
+
+import android.content.Context;
+import android.content.ContextWrapper;
+import android.content.res.Configuration;
+import android.os.Build;
+
+import java.util.Locale;
+
+public class NewPassContextWrapper extends ContextWrapper {
+
+    public NewPassContextWrapper(Context base) {
+        super(base);
+    }
+
+    public static ContextWrapper wrap(Context context, String language) {
+        Configuration config = context.getResources().getConfiguration();
+        Locale sysLocale;
+        if (Build.VERSION.SDK_INT > Build.VERSION_CODES.N) {
+            sysLocale = getSystemLocale(config);
+        } else {
+            sysLocale = getSystemLocaleLegacy(config);
+        }
+        if (!language.isEmpty() && !sysLocale.getLanguage().equals(language)) {
+            Locale locale = new Locale(language);
+            Locale.setDefault(locale);
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+                setSystemLocale(config, locale);
+            } else {
+                setSystemLocaleLegacy(config, locale);
+            }
+
+        }
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+            context = context.createConfigurationContext(config);
+        } else {
+            context.getResources().updateConfiguration(config, context.getResources().getDisplayMetrics());
+        }
+        return new NewPassContextWrapper(context);
+    }
+
+    public static Locale getSystemLocaleLegacy(Configuration config) {
+        return config.locale;
+    }
+
+    public static Locale getSystemLocale(Configuration config) {
+        return config.getLocales().get(0);
+    }
+
+    public static void setSystemLocaleLegacy(Configuration config, Locale locale) {
+        config.locale = locale;
+    }
+
+    public static void setSystemLocale(Configuration config, Locale locale) {
+        config.setLocale(locale);
+    }
+}

--- a/app/src/main/java/com/gero/newpass/SharedPreferences/SharedPreferencesHelper.java
+++ b/app/src/main/java/com/gero/newpass/SharedPreferences/SharedPreferencesHelper.java
@@ -1,0 +1,93 @@
+package com.gero.newpass.SharedPreferences;
+
+import android.app.Activity;
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.view.View;
+import android.view.Window;
+
+import androidx.appcompat.app.AppCompatDelegate;
+
+import com.gero.newpass.R;
+
+public class SharedPreferencesHelper {
+
+    public static String DARK_MODE_FLAG = "isDarkModeOn";
+    public static String SHARED_PREF_FLAG = "SharedPref";
+    public static String LANG_PREF_FLAG = "language";
+
+    //Obtain shared preferences
+    public static synchronized SharedPreferences getSharedPreferences(Context context) {
+        SharedPreferences sharedPreferences = context.getSharedPreferences(SHARED_PREF_FLAG, Context.MODE_PRIVATE);
+        return sharedPreferences;
+    }
+
+    //Return is dark mode is set or not from shared preferences, default value is true
+    public static Boolean isDarkModeSet(Context context) {
+        SharedPreferences sharedPreferences = getSharedPreferences(context);
+        return sharedPreferences.getBoolean(DARK_MODE_FLAG, true);
+    }
+
+    //Set dark mode using app compat delegate
+    public static void setDarkMode() {
+        AppCompatDelegate
+                .setDefaultNightMode(
+                        AppCompatDelegate
+                                .MODE_NIGHT_YES);
+    }
+
+    //Set light mode using app compat delegate
+    public static void setLightMode() {
+        AppCompatDelegate
+                .setDefaultNightMode(
+                        AppCompatDelegate
+                                .MODE_NIGHT_NO);
+    }
+
+    //Edit dark mode shared preferences when needed (eg settings) for dark mode
+    public static void setAndEditSharedPrefForDarkMode(Context context) {
+        SharedPreferences sharedPreferences = getSharedPreferences(context);
+        final SharedPreferences.Editor editor = sharedPreferences.edit();
+        setDarkMode();
+        editor.putBoolean(
+                DARK_MODE_FLAG, true);
+        editor.apply();
+    }
+
+    //Edit dark mode shared preferences when needed (eg settings) for light mode
+    public static void setAndEditSharedPrefForLightMode(Context context) {
+        SharedPreferences sharedPreferences = getSharedPreferences(context);
+        final SharedPreferences.Editor editor = sharedPreferences.edit();
+        setLightMode();
+        editor.putBoolean(
+                DARK_MODE_FLAG, false);
+        editor.apply();
+    }
+
+    //Apply dark/ light mode based on shared preferences on UI, including the navigation bar
+    public static void toggleDarkLightModeUI(Activity activity) {
+        Boolean isDarkModeSet = isDarkModeSet(activity.getApplicationContext());
+        if (isDarkModeSet) {
+            setDarkMode();
+        } else {
+            setLightMode();
+        }
+        updateNavigationBarColor(isDarkModeSet, activity);
+    }
+
+    //Apply dark/ light mode on the navigation bar
+    public static void updateNavigationBarColor(Boolean isDarkMode, Activity activity) {
+        Window window = activity.getWindow();
+        if (isDarkMode) {
+            // Set dark color for navigation bar
+            window.setNavigationBarColor(activity.getResources().getColor(R.color.navigationbar_dark_mode));
+        } else {
+            // Set light color for navigation bar
+            window.setNavigationBarColor(activity.getResources().getColor(R.color.navigationbar_light_mode));
+            // Additionally, if your navigation bar icons are not visible against the light background, you can make them dark:
+            window.getDecorView().setSystemUiVisibility(View.SYSTEM_UI_FLAG_LIGHT_NAVIGATION_BAR);
+        }
+    }
+
+
+}

--- a/app/src/main/java/com/gero/newpass/encryption/EncryptionHelper.java
+++ b/app/src/main/java/com/gero/newpass/encryption/EncryptionHelper.java
@@ -1,7 +1,6 @@
 package com.gero.newpass.encryption;
 
 import android.content.Context;
-import android.content.SharedPreferences;
 import android.security.keystore.KeyGenParameterSpec;
 import android.security.keystore.KeyProperties;
 import android.util.Base64;
@@ -145,11 +144,6 @@ public class EncryptionHelper {
             }
         }
         return encryptedSharedPreferences;
-    }
-
-    public static synchronized SharedPreferences getSharedPreferences(Context context) {
-        SharedPreferences sharedPreferences = context.getSharedPreferences("SharedPref", Context.MODE_PRIVATE);
-        return sharedPreferences;
     }
 
 }

--- a/app/src/main/java/com/gero/newpass/view/activities/LoginActivity.java
+++ b/app/src/main/java/com/gero/newpass/view/activities/LoginActivity.java
@@ -1,34 +1,31 @@
 package com.gero.newpass.view.activities;
 
 import androidx.appcompat.app.AppCompatActivity;
-import androidx.appcompat.app.AppCompatDelegate;
 import androidx.lifecycle.ViewModelProvider;
 import androidx.security.crypto.EncryptedSharedPreferences;
-import androidx.security.crypto.MasterKey;
 
 import android.annotation.SuppressLint;
+import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.content.res.Configuration;
 import android.content.res.Resources;
 import android.os.Bundle;
-import android.util.Log;
 import android.view.View;
-import android.view.Window;
 import android.widget.EditText;
 import android.widget.ImageButton;
 import android.widget.TextView;
 import android.widget.Toast;
 
+import com.gero.newpass.ContextWrapper.NewPassContextWrapper;
 import com.gero.newpass.R;
+import com.gero.newpass.SharedPreferences.SharedPreferencesHelper;
 import com.gero.newpass.encryption.EncryptionHelper;
 import com.gero.newpass.utilities.StringUtility;
 import com.gero.newpass.utilities.SystemBarColorHelper;
 import com.gero.newpass.viewmodel.LoginViewModel;
 import com.gero.newpass.databinding.ActivityLoginBinding;
 
-import java.io.IOException;
-import java.security.GeneralSecurityException;
 import java.util.Locale;
 
 public class LoginActivity extends AppCompatActivity {
@@ -49,9 +46,7 @@ public class LoginActivity extends AppCompatActivity {
         setContentView(binding.getRoot());
         SystemBarColorHelper.changeBarsColor(this, R.color.background_primary);
 
-        sharedPreferences = EncryptionHelper.getSharedPreferences(getApplicationContext());
-
-        setLocale(getPreferredLanguage());
+//        setLocale(getPreferredLanguage());
 
         initViews(binding);
 
@@ -75,7 +70,8 @@ public class LoginActivity extends AppCompatActivity {
 
         encryptedSharedPreferences = EncryptionHelper.getEncryptedSharedPreferences(getApplicationContext());
 
-        setDarkMode();
+        //Determining whether to set dark or light mode based on shared preferences
+        SharedPreferencesHelper.toggleDarkLightModeUI(this);
 
         String password = encryptedSharedPreferences.getString("password", "");
         Boolean isPasswordEmpty = password.isEmpty();
@@ -108,48 +104,17 @@ public class LoginActivity extends AppCompatActivity {
         textViewRegisterOrUnlock = binding.registerOrUnlockTextView;
     }
 
-    private void setDarkMode() {
-        //Checking if dark mode is set or not from shared  preferences, default value being True
-        Boolean isDarkModeSet = sharedPreferences.getBoolean("isDarkModeOn", true);
-
-        if (isDarkModeSet) {
-            AppCompatDelegate
-                    .setDefaultNightMode(
-                            AppCompatDelegate
-                                    .MODE_NIGHT_YES);
-        } else {
-            AppCompatDelegate
-                    .setDefaultNightMode(
-                            AppCompatDelegate
-                                    .MODE_NIGHT_NO);
-        }
-        updateNavigationBarColor(isDarkModeSet);
-    }
-
-    private void updateNavigationBarColor(Boolean isDarkMode) {
-        Window window = getWindow();
-        if (isDarkMode) {
-            // Set dark color for navigation bar
-            window.setNavigationBarColor(getResources().getColor(R.color.navigationbar_dark_mode));
-        } else {
-            // Set light color for navigation bar
-            window.setNavigationBarColor(getResources().getColor(R.color.navigationbar_light_mode));
-            // Additionally, if your navigation bar icons are not visible against the light background, you can make them dark:
-            window.getDecorView().setSystemUiVisibility(View.SYSTEM_UI_FLAG_LIGHT_NAVIGATION_BAR);
-        }
-    }
-
-    private String getPreferredLanguage() {
-        SharedPreferences.Editor editor = sharedPreferences.edit();
-
-        if (sharedPreferences.getString("language", "").isEmpty()) {
-            String languageOfTheDevice = Locale.getDefault().getLanguage();
-            editor.putString("language", languageOfTheDevice);
-            editor.apply();
-        }
-
-        return sharedPreferences.getString("language", "");
-    }
+//    private String getPreferredLanguage() {
+//        SharedPreferences.Editor editor = sharedPreferences.edit();
+//
+//        if (sharedPreferences.getString("language", "").isEmpty()) {
+//            String languageOfTheDevice = Locale.getDefault().getLanguage();
+//            editor.putString("language", languageOfTheDevice);
+//            editor.apply();
+//        }
+//
+//        return sharedPreferences.getString("language", "");
+//    }
 
     private void setLocale(String languageCode) {
         Locale locale = new Locale(languageCode);
@@ -158,5 +123,17 @@ public class LoginActivity extends AppCompatActivity {
         Configuration configuration = resources.getConfiguration();
         configuration.setLocale(locale);
         resources.updateConfiguration(configuration, resources.getDisplayMetrics());
+    }
+
+    @Override
+    protected void attachBaseContext(Context context) {
+        sharedPreferences = context.getSharedPreferences(SharedPreferencesHelper.SHARED_PREF_FLAG, MODE_PRIVATE);
+        String language = sharedPreferences.getString(SharedPreferencesHelper.LANG_PREF_FLAG, "en");
+        super.attachBaseContext(NewPassContextWrapper.wrap(context, language));
+        Locale locale = new Locale(language);
+        Resources resources = getBaseContext().getResources();
+        Configuration conf = resources.getConfiguration();
+        conf.locale = locale;
+        resources.updateConfiguration(conf, resources.getDisplayMetrics());
     }
 }

--- a/app/src/main/java/com/gero/newpass/view/activities/MainViewActivity.java
+++ b/app/src/main/java/com/gero/newpass/view/activities/MainViewActivity.java
@@ -1,28 +1,29 @@
 package com.gero.newpass.view.activities;
 
+import android.content.Context;
 import android.content.SharedPreferences;
+import android.content.res.Configuration;
+import android.content.res.Resources;
 import android.os.Bundle;
-import android.view.View;
-import android.view.Window;
 
 import androidx.appcompat.app.AppCompatActivity;
-import androidx.appcompat.app.AppCompatDelegate;
 import androidx.fragment.app.Fragment;
 
 
+import com.gero.newpass.ContextWrapper.NewPassContextWrapper;
+import com.gero.newpass.SharedPreferences.SharedPreferencesHelper;
 import com.gero.newpass.database.DatabaseServiceLocator;
 import com.gero.newpass.databinding.ActivityMainViewBinding;
 
 import com.gero.newpass.R;
-import com.gero.newpass.encryption.EncryptionHelper;
 import com.gero.newpass.utilities.SystemBarColorHelper;
 import com.gero.newpass.view.fragments.MainViewFragment;
+
+import java.util.Locale;
 
 public class MainViewActivity extends AppCompatActivity {
 
     private ActivityMainViewBinding binding;
-
-    private SharedPreferences sharedPreferences;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -46,22 +47,7 @@ public class MainViewActivity extends AppCompatActivity {
     @Override
     public void onResume() {
         super.onResume();
-        sharedPreferences = EncryptionHelper.getSharedPreferences(this.getApplicationContext());
-        //Checking if dark mode is set or not from shared  preferences, default value being True
-        Boolean isDarkModeSet = sharedPreferences.getBoolean("isDarkModeOn", true);
-        if (isDarkModeSet) {
-            AppCompatDelegate
-                    .setDefaultNightMode(
-                            AppCompatDelegate
-                                    .MODE_NIGHT_YES);
-        }
-        else {
-            AppCompatDelegate
-                    .setDefaultNightMode(
-                            AppCompatDelegate
-                                    .MODE_NIGHT_NO);
-        }
-        updateNavigationBarColor(isDarkModeSet);
+        SharedPreferencesHelper.toggleDarkLightModeUI(this);
     }
 
     public void openFragment(Fragment fragment) {
@@ -86,17 +72,16 @@ public class MainViewActivity extends AppCompatActivity {
         }
     }
 
-    public void updateNavigationBarColor(Boolean isDarkMode){
-        Window window = getWindow();
-        if (isDarkMode) {
-            // Set dark color for navigation bar
-            window.setNavigationBarColor(getResources().getColor(R.color.navigationbar_dark_mode));
-        } else {
-            // Set light color for navigation bar
-            window.setNavigationBarColor(getResources().getColor(R.color.navigationbar_light_mode));
-            // Additionally, if your navigation bar icons are not visible against the light background, you can make them dark:
-            window.getDecorView().setSystemUiVisibility(View.SYSTEM_UI_FLAG_LIGHT_NAVIGATION_BAR);
-        }
+    @Override
+    protected void attachBaseContext(Context context) {
+        SharedPreferences sharedPreferences = context.getSharedPreferences(SharedPreferencesHelper.SHARED_PREF_FLAG, MODE_PRIVATE);
+        String language = sharedPreferences.getString(SharedPreferencesHelper.LANG_PREF_FLAG, "en");
+        super.attachBaseContext(NewPassContextWrapper.wrap(context, language));
+        Locale locale = new Locale(language);
+        Resources resources = getBaseContext().getResources();
+        Configuration conf = resources.getConfiguration();
+        conf.locale = locale;
+        resources.updateConfiguration(conf, resources.getDisplayMetrics());
     }
 
 }

--- a/app/src/main/java/com/gero/newpass/view/fragments/SettingsFragment.java
+++ b/app/src/main/java/com/gero/newpass/view/fragments/SettingsFragment.java
@@ -1,7 +1,5 @@
 package com.gero.newpass.view.fragments;
 
-import static android.content.Context.MODE_PRIVATE;
-
 import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.content.Intent;
@@ -12,7 +10,6 @@ import android.os.Bundle;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AlertDialog;
-import androidx.appcompat.app.AppCompatDelegate;
 import androidx.fragment.app.Fragment;
 
 import android.util.Log;
@@ -23,10 +20,9 @@ import android.widget.ImageButton;
 import android.widget.ImageView;
 
 import com.gero.newpass.R;
+import com.gero.newpass.SharedPreferences.SharedPreferencesHelper;
 import com.gero.newpass.databinding.FragmentSettingsBinding;
-import com.gero.newpass.encryption.EncryptionHelper;
 import com.gero.newpass.view.activities.MainViewActivity;
-
 
 
 public class SettingsFragment extends Fragment {
@@ -86,24 +82,14 @@ public class SettingsFragment extends Fragment {
         //Dark mode toggle button listener
         binding.toggleDarkMode.setOnCheckedChangeListener((buttonView, isChecked) -> {
             if (isChecked && !isDarkModeSet) {
-                AppCompatDelegate
-                        .setDefaultNightMode(
-                                AppCompatDelegate
-                                        .MODE_NIGHT_YES);
-                editor.putBoolean(
-                        "isDarkModeOn", true);
-                editor.apply();
+                SharedPreferencesHelper.setAndEditSharedPrefForDarkMode(
+                        this.requireActivity().getApplicationContext());
             } else if (!isChecked && isDarkModeSet) {
-                AppCompatDelegate
-                        .setDefaultNightMode(
-                                AppCompatDelegate
-                                        .MODE_NIGHT_NO);
-                editor.putBoolean(
-                        "isDarkModeOn", false);
-                editor.apply();
+                SharedPreferencesHelper.setAndEditSharedPrefForLightMode(
+                        this.requireActivity().getApplicationContext());
             }
             if (activity instanceof MainViewActivity) {
-                ((MainViewActivity) activity).updateNavigationBarColor(isChecked);
+                SharedPreferencesHelper.updateNavigationBarColor(isChecked, activity);
             }
         });
 
@@ -119,8 +105,8 @@ public class SettingsFragment extends Fragment {
             builder.setSingleChoiceItems(languages, -1, (dialog, which) -> {
                 String selectedLanguage = languages[which];
 
-                Log.i("234523", "switching to " + selectedLanguage.toLowerCase().substring(0,2));
-                editor.putString("language", selectedLanguage.toLowerCase().substring(0,2));
+                Log.i("234523", "switching to " + selectedLanguage.toLowerCase().substring(0, 2));
+                editor.putString(SharedPreferencesHelper.LANG_PREF_FLAG, selectedLanguage.toLowerCase().substring(0, 2));
                 editor.apply();
                 dialog.dismiss();
 
@@ -141,10 +127,10 @@ public class SettingsFragment extends Fragment {
         IVContact = binding.imageViewContact;
         IVLanguage = binding.imageViewLanguage;
 
-        //Dark mode toggle initialization, and language mode
-        sharedPreferences = EncryptionHelper.getSharedPreferences(this.requireActivity().getApplicationContext());
+        //shared preferences for language mode
+        sharedPreferences = SharedPreferencesHelper.getSharedPreferences(this.requireActivity().getApplicationContext());
 
-        isDarkModeSet = sharedPreferences.getBoolean("isDarkModeOn", true);
+        isDarkModeSet = SharedPreferencesHelper.isDarkModeSet(this.requireActivity().getApplicationContext());
 
         binding.toggleDarkMode.setChecked(isDarkModeSet);
     }


### PR DESCRIPTION
- Migrated common shared preferences code to a helper class to avoid duplication of code
- Created a custom context wrapper to apply the language instead of recreating the activity. This will fix the issue.

Screen recording: 

https://github.com/6eero/NewPass/assets/33260602/f9a24ba3-595c-4e41-872e-78a01891fce6

